### PR TITLE
Script updates

### DIFF
--- a/build-newlib.sh
+++ b/build-newlib.sh
@@ -6,7 +6,7 @@ opts=`getopt -o v:dn --long newlib-version:,diff,nopatch -- "$@"`
 
 eval set -- "$opts"
 
-ver=4.4.0.20231231  #an ugly version number, but there's no 4.4.0 and this is the latest release
+ver=4.5.0.20241231  #an ugly version number, but there's no 4.5.0 and this is the latest release
 root=`pwd`
 target=x86_64-pc-baremetal
 diff=false

--- a/setup-newlib.sh
+++ b/setup-newlib.sh
@@ -3,11 +3,11 @@
 set -e
 
 # Confirmation prompt
-echo "This script will remove the currently installed autoconf and automake, download and install autoconf-2.69 and automake-1.15.1, and adjust the path variable. sudo will be used. Are you sure? Type 'yes' to continue."
-read -r response
+echo "This script will remove the currently installed autoconf and automake, download and install autoconf-2.69 and automake-1.15.1, and adjust the path variable. sudo will be used. Are you sure?"
+read -p "Enter 'yes' to continue: " -r response
 if [ "$response" != "yes" ]; then
-    echo "Aborting..."
-    exit 1
+	echo "Aborting..."
+	exit 1
 fi
 
 # Remove autoconf and automake


### PR DESCRIPTION
This pull request contains two minor updates: one updates the default version of Newlib used in the build script, and the other improves the user prompt in the setup script to make it clearer when user confirmation is required.

- Version update:
  * Updated the default `ver` variable in `build-newlib.sh` to use Newlib version `4.5.0.20241231` instead of `4.4.0.20231231`.

- Usability improvement:
  * Changed the confirmation prompt in `setup-newlib.sh` to use a more explicit `read -p` message, making it clearer to the user that they must enter 'yes' to continue.